### PR TITLE
recursively transformDates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,18 +168,21 @@ export class SerializedDocument {
 }
 
 function transformDates(serializedDocument: any) {
-    Object.keys(serializedDocument.data).forEach(property => {
-        if (typeof serializedDocument.data[property] === 'object') {
-            if (Array.isArray(serializedDocument.data[property])){
-                serializedDocument.data[property].forEach((obj: any, index: string | number) => {
-                    serializedDocument.data[property][index] = transformDates(obj);
+    return transformDatesHelper(serializedDocument.data);
+}
+function transformDatesHelper(data: any) {
+    Object.keys(data).forEach(property => {
+        if (typeof data[property] === 'object') {
+            if (Array.isArray(data[property])){
+                data[property].forEach((obj: any, index: string | number) => {
+                    data[property][index] = transformDatesHelper(obj);
                 });
             }
-            else if (typeof serializedDocument.data[property]?.toDate === 'function')
-                serializedDocument.data[property] = serializedDocument.data[property].toDate();
+            else if (typeof data[property]?.toDate === 'function')
+                data[property] = data[property].toDate();
             else
-                serializedDocument.data[property] = transformDates(serializedDocument.data[property]);
+                data[property] = transformDatesHelper(data[property]);
         }
     });
-    return serializedDocument;
+    return data;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,9 +169,17 @@ export class SerializedDocument {
 
 function transformDates(serializedDocument: any) {
     Object.keys(serializedDocument.data).forEach(property => {
-        if (serializedDocument.data[property]?.toDate !== undefined) {
-            serializedDocument.data[property] = serializedDocument.data[property].toDate()
+        if (typeof serializedDocument.data[property] === 'object') {
+            if (Array.isArray(serializedDocument.data[property])){
+                serializedDocument.data[property].forEach((obj: any, index: string | number) => {
+                    serializedDocument.data[property][index] = transformDates(obj);
+                });
+            }
+            else if (typeof serializedDocument.data[property]?.toDate === 'function')
+                serializedDocument.data[property] = serializedDocument.data[property].toDate();
+            else
+                serializedDocument.data[property] = transformDates(serializedDocument.data[property]);
         }
-    })
+    });
     return serializedDocument;
 }


### PR DESCRIPTION
## Description

adjusted `transformDates` function to check recursively for the `toDate()` funciton inside of any objects within the `serializedDocument`.

I'm assuming here that `toDate()` is a property inside an object.

Closes #1 .

- Link(s) to related 3rd party documentation, solved issue(s), commit(s) & PR(s)