### PR TITLE
Feat/2/cache includes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "git",
     "url": "https://github.com/HealthTree/firestore-join"
   },
-  "version": "0.4.4",
+  "version": "0.4.6",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,11 @@ import DocumentSnapshot = firebase.firestore.DocumentSnapshot
 import QuerySnapshot = firebase.firestore.QuerySnapshot
 import Query = firebase.firestore.Query;
 
-const cacheTimeout = 3000;
+let cacheTimeout: number = 3000;
 
 let documentReferencePromiseMapCache: { [key: string]: CachedDocumentSnapshotPromise } = {};
 
 let serializedDocumentTransformer: Function = transformDates;
-
-export function setSerializedDocumentTransformer(transformerFunction: Function) {
-    serializedDocumentTransformer = transformerFunction;
-}
 
 export interface CachedDocumentSnapshotPromise extends Promise<DocumentSnapshot>{
     time: number
@@ -247,6 +243,14 @@ function transformDatesHelper(data: { [key: string]: any }) {
 
 function isPlainObject(value: any) {
     return Object.prototype.toString.call(value) == '[object Object]' && value.constructor.name === 'Object';
+}
+
+export function setCacheTimeout(milliseconds: number) {
+    cacheTimeout = milliseconds;
+}
+
+export function setSerializedDocumentTransformer(transformerFunction: Function) {
+    serializedDocumentTransformer = transformerFunction;
 }
 
 export function getCachedDocumentSnapshotPromise(documentReference: DocumentReference): CachedDocumentSnapshotPromise {


### PR DESCRIPTION
## Description

- Added cache to any documentReferences fetched from firebase-join.

No api changes, you just need to know that there is a 3 second cache for all `documentReferences` fetched either by includes or by calling `.fromDocumentReference` builder.

- Extra helper methods:

`.fromQuery` can be used if you are lazy and don't want to call .get() yourself.

If you don't need to wait / want for any includes (relations)
```js
const coachingSessions = await SerializedDocumentArray.fromQuery(db
      .collection('apps/coach/coachingSessions')
      .where('disease', '==', $CurrentDiseaseStore.ref), {})
```

If you want to wait for includes
```js
const coachingSessions = await SerializedDocumentArray.fromQuery(db
      .collection('apps/coach/coachingSessions')
      .where('disease', '==', $CurrentDiseaseStore.ref), {patient: true, coach: true}).ready()
```

`.fromDocumentReferenceArray` can be used to fetch and serialize an array of document references. Eventually we'll need this when working with results that come from bigquery etc (get me all my list of treatments) we can just return the ids and use this method to get any extra data we may want.

```js
const coachingSessions = await SerializedDocumentArray.fromDocumentReferenceArray(
[documentReference1, documentReference2], 
{patient: true, coach: true}).ready() //skip ready if you don't want to wait for includes
```

`.fromDocumentReference` useful to get and serialize a single document. Used internally but it may be handy in some other cases from the application or if you are lazy and don't want to call .get()
```js
const coachingSession = await SerializedDocument.fromDocumentReference(
db.collection('apps/coach/coachingSessions').doc(id), 
{patient: true, coach: true}).ready() //skip ready if you don't want to wait for includes
```
Closes #2 